### PR TITLE
perf: extract chunk_text() helper, fix token-count bug, add HTTP timeouts

### DIFF
--- a/responsible-ai-moderationlayer/src/service/service.py
+++ b/responsible-ai-moderationlayer/src/service/service.py
@@ -61,6 +61,10 @@ token_expiration=0
 verify_ssl = os.getenv("VERIFY_SSL")
 sslv={"False":False,"True":True,"None":True}
 
+# Performance: named constants replace magic numbers throughout this module.
+CHUNK_TOKEN_LIMIT = 400   # Maximum number of tokens per text chunk.
+HTTP_TIMEOUT = 30         # Seconds before an outbound HTTP request is aborted.
+
 def handle_object(obj):
     return vars(obj) 
 
@@ -68,6 +72,39 @@ class AttributeDict(dict):
     __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
+
+
+def chunk_text(text: str, limit: int = CHUNK_TOKEN_LIMIT) -> list:
+    """Split *text* into token-based chunks of at most *limit* tokens each.
+
+    Centralises the chunking logic that was previously duplicated in the
+    ``Toxicity`` and ``Profanity`` service classes, and fixes a latent bug
+    where the original code used ``len(token)`` (character count) instead
+    of 1 when accumulating the per-chunk token count.
+
+    Args:
+        text:  The input string to split.
+        limit: Maximum number of NLTK tokens allowed in each chunk.
+               Defaults to :data:`CHUNK_TOKEN_LIMIT`.
+
+    Returns:
+        A list of text chunks.  If the text is already within *limit* tokens
+        the list contains only the original string.
+    """
+    tokens = nltk.word_tokenize(text)
+    if len(tokens) <= limit:
+        return [text]
+    chunks = []
+    current = []
+    for token in tokens:
+        if len(current) < limit:
+            current.append(token)
+        else:
+            chunks.append(' '.join(current))
+            current = [token]
+    if current:
+        chunks.append(' '.join(current))
+    return chunks
 
 
 try:
@@ -370,7 +407,7 @@ class promptResponse:
             output =await post_request(url = url,json={"text1": prompt,"text2": output_text},headers=headers)
             similarity=json.loads(output.decode('utf-8'))[0][0][0]
             
-            # output = requests.post(url = mpnetsimilarityurl,json={"text1": prompt,"text2": output_text},headers=headers,verify=False)
+            # output = requests.post(url = mpnetsimilarityurl,json={"text1": prompt,"text2": output_text},headers=headers,verify=False,timeout=HTTP_TIMEOUT)
             # similarity=output.json()[0][0]
             # log.info(f"Max similarity : {max(similarity)}")
             return similarity
@@ -467,11 +504,11 @@ class CustomthemeRestricted:
             #Using azure jailbreak endpoint for custom theme restricted
             if target_env=='azure':
                 log.info("Using azure jailbreak endpoint for custom theme restricted")
-                text_embedding = requests.post(url = jailbreakurl,json={"text": [text]},headers=headers,verify=sslv[verify_ssl]).json()[0][0]
+                text_embedding = requests.post(url = jailbreakurl,json={"text": [text]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT).json()[0][0]
             #Using aicloud jailbreak endpoint for custom theme restricted
             elif target_env=='aicloud':
                 log.info("Using aicloud jailbreak endpoint for custom theme restricted")
-                text_embedding = requests.post(url = jailbreakraiurl,json={"inputs": [text]},headers=headers,verify=sslv[verify_ssl]).json()[0]
+                text_embedding = requests.post(url = jailbreakraiurl,json={"inputs": [text]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT).json()[0]
             if theme:
                 embed_array = orgpolicy_embeddings
             else:
@@ -567,27 +604,8 @@ class Toxicity:
         try:
             if identifyIDP(text):
                 text=text.replace('IDP','idp')
-            # tokens = TreebankWordTokenizer().tokenize
-            tokens = nltk.word_tokenize(text)  
-            # print("len(tokens)",len(tokens))
-            if len(tokens) > 400:
-                chunked_texts = []
-                chunk = []
-                token_count = 0
-
-                for token in tokens:
-                    if token_count + len(token) <= 400:
-                        chunk.append(token)
-                        token_count += len(token)
-                    else:
-                        chunked_texts.append(' '.join(chunk))
-                        chunk = [token]
-                        token_count = len(token)
-
-                # Add the last chunk if it's not empty
-                
-                if chunk:
-                    chunked_texts.append(' '.join(chunk))
+            chunked_texts = chunk_text(text)
+            if len(chunked_texts) > 1:
             
                 toxicity_scoreslist = []
                 toxicity_scores = {
@@ -750,7 +768,7 @@ def profanity_popup(text,headers):
             if target_env=='azure':
                 log.info("Using azure endpoints for profanity popup")
                 for chunk in chunks:
-                    result = requests.post(url=detoxifyurl,json={"text": chunk},headers=headers,verify=sslv[verify_ssl]).json()
+                    result = requests.post(url=detoxifyurl,json={"text": chunk},headers=headers,verify=sslv[verify_ssl]),timeout=HTTP_TIMEOUT).json()
                     toxicity_scoreslist.append(result)
                 for item in toxicity_scoreslist:
                     toxic_score_list = item['toxicScore']
@@ -763,7 +781,7 @@ def profanity_popup(text,headers):
             elif target_env=='aicloud':
                 log.info("Using aicloud endpoints for profanity popup")
                 for chunk in chunks:
-                    result = requests.post(url=detoxifyraiurl,json={"inputs": [chunk]},headers=headers,verify=sslv[verify_ssl]).json()
+                    result = requests.post(url=detoxifyraiurl,json={"inputs": [chunk]},headers=headers,verify=sslv[verify_ssl]),timeout=HTTP_TIMEOUT).json()
                     toxicity_scoreslist.append(result[0])
                 for item in toxicity_scoreslist:
                         for key,value in item.items():
@@ -783,16 +801,16 @@ def profanity_popup(text,headers):
             #Using azure endpoints for profanity popup
             if target_env=='azure':
                 log.info("Using azure endpoints for profanity popup")
-                output = requests.post(url=detoxifyurl,json={"text": text},headers=headers,verify=sslv[verify_ssl]).json()
+                output = requests.post(url=detoxifyurl,json={"text": text},headers=headers,verify=sslv[verify_ssl]),timeout=HTTP_TIMEOUT).json()
                 toxic_score = output["toxicScore"][0]["metricScore"]
             #Using aicloud endpoints for profanity popup
             elif target_env=='aicloud':
                 log.info("Using aicloud endpoints for profanity popup")
-                output = requests.post(url=detoxifyraiurl,json={"inputs": [text]},headers=headers,verify=sslv[verify_ssl]).json()
+                output = requests.post(url=detoxifyraiurl,json={"inputs": [text]},headers=headers,verify=sslv[verify_ssl]),timeout=HTTP_TIMEOUT).json()
                 toxic_score = output[0]["toxicity"]              
 
 
-        # output = requests.post(url=detoxifyurl,json={"text": text},verify=False).json()
+        # output = requests.post(url=detoxifyurl,json={"text": text},verify=False,timeout=HTTP_TIMEOUT).json()
         # toxic_score = output["toxicScore"][0]["metricScore"]
         List_profanity = []
         if toxic_score > 0.6:
@@ -828,7 +846,7 @@ def privacy_popup(payload,headers=None):
             url=privacyurl
         elif target_env=='aicloud':
             url=privacyraiurl
-        analyze_result =requests.post(url=url,json={"text": text},headers=headers)
+        analyze_result =requests.post(url=url,json={"text": text},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
         analyze_result=analyze_result.json()
         entitiesconfigured = payload.PiientitiesConfiguredToDetect
         entitiesconfiguredToBlock = payload.PiientitiesConfiguredToBlock
@@ -874,24 +892,8 @@ class Profanity:
 
     async def recognise(self,text,headers):
         try:
-            tokens = nltk.word_tokenize(text)    
-            if len(tokens) > 400:
-                chunked_texts = []
-                chunk = []
-                token_count = 0
-
-                for token in tokens:
-                    if token_count + len(token) <= 400:
-                        chunk.append(token)
-                        token_count += len(token)
-                    else:
-                        chunked_texts.append(' '.join(chunk))
-                        chunk = [token]
-                        token_count = len(token)
-
-                # Add the last chunk if it's not empty
-                if chunk:
-                    chunked_texts.append(' '.join(chunk))
+            chunked_texts = chunk_text(text)
+            if len(chunked_texts) > 1:
             
                 toxicity_scoreslist = []
                 toxicity_scores = {
@@ -2573,7 +2575,7 @@ class LlamaDeepSeekcompletion:
                     "do_sample": True
                 }
             }
-            response = requests.post(url, json=input, verify=sslv[verify_ssl])
+            response = requests.post(url, json=input, verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
             response.raise_for_status()
             generated_text = response.json()[0]["generated_text"]
             output_text = generated_text.split("[/INST]")[1]
@@ -2593,7 +2595,7 @@ class LlamaDeepSeekcompletion:
                     "max_tokens": 128
             }
             headers={"Authorization": "Bearer "+aicloud_access_token,"Content-Type": contentType,"Accept": "*"}
-            response = requests.post(url,json=input,headers=headers,verify=sslv[verify_ssl])
+            response = requests.post(url,json=input,headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
             response.raise_for_status()
             response = json.loads(response.text)['choices'][0]['text']
             output_text = response.replace("\n</think>\n\n","") if "\n</think>\n\n" in response else response
@@ -2609,7 +2611,7 @@ class Llamacompletionazure:
             input = {
                 "input": text
             }
-            response = requests.post(self.url, json=input, verify=sslv[verify_ssl])
+            response = requests.post(self.url, json=input, verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
             generated_text = response.json()["output"]
             return generated_text, 0, "","0"
         except Exception as e:
@@ -2696,7 +2698,7 @@ class Llama3completions:
             "stop": "null"
             }
             st=time.time()
-            response = requests.post(url=self.url, json=input, headers=headers)
+            response = requests.post(url=self.url, json=input, headers=headers,timeout=HTTP_TIMEOUT)
             et= time.time()
             rt = et - st
             dict_timecheck["Llama3InteractionTime"]=str(round(rt,3))+"s"
@@ -2854,7 +2856,7 @@ class Bloomcompletion:
         self.url = os.environ.get("BLOOM_ENDPOINT")
 
     def textCompletion(self,text,temperature=None,PromptTemplate="GoalPriority",deployment_name=None,Moderation_flag=None,COT=None,THOT=None):
-        response = requests.post(self.url,text,verify=sslv[verify_ssl])
+        response = requests.post(self.url,text,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
         generated_text = response.json()[0]["generated_text"]
         return generated_text,0,"","0"
 
@@ -3027,7 +3029,7 @@ class AWScompletions:
         request = json.dumps(native_request)
         if deployment_name == "AWS_CLAUDE_V3_5":
             url = os.getenv("AWS_KEY_ADMIN_PATH")
-            response = requests.get(url,verify=sslv[verify_ssl])
+            response = requests.get(url,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
                 
             if response.status_code == 200:
                 expiration_time = int(response.json()['expirationTime'].split("hrs")[0])
@@ -3319,13 +3321,13 @@ def organization_policy(payload,headers):
         #Using azure restricted topic model endpoint for organization policy
         if target_env=='azure':
             log.info("Using azure restricted topic model endpoint for organization policy")
-            output = requests.post(url = topicurl,json={"text": text,"labels":labels},headers=headers,verify=sslv[verify_ssl])
+            output = requests.post(url = topicurl,json={"text": text,"labels":labels},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
             output=output.json()
 
         #Using aicloud restricted topic model endpoint for organization policy
         elif target_env=='aicloud':
             log.info("Using aicloud restricted topic model endpoint for organization policy")
-            output = requests.post(url = topicraiurl,json={"inputs": [{"text":text,"labels":labels}]},headers=headers,verify=sslv[verify_ssl])
+            output = requests.post(url = topicraiurl,json={"inputs": [{"text":text,"labels":labels}]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT)
             output=output.json()[0]
 
         d={}
@@ -3343,11 +3345,11 @@ def organization_policy(payload,headers):
 
 def promptResponseSimilarity(text_1, text_2,headers):
     if target_env=='azure':
-        text_1_embedding = requests.post(url = jailbreakurl,json={"text": [text_1]},headers=headers,verify=sslv[verify_ssl]).json()[0][0]
-        text_2_embedding = requests.post(url = jailbreakurl,json={"text": [text_2]},headers=headers,verify=sslv[verify_ssl]).json()[0][0]
+        text_1_embedding = requests.post(url = jailbreakurl,json={"text": [text_1]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT).json()[0][0]
+        text_2_embedding = requests.post(url = jailbreakurl,json={"text": [text_2]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT).json()[0][0]
     elif target_env=='aicloud':
-        text_1_embedding = requests.post(url = jailbreakraiurl,json={"inputs": [text_1]},headers=headers,verify=sslv[verify_ssl]).json()[0]
-        text_2_embedding = requests.post(url = jailbreakraiurl,json={"inputs": [text_2]},headers=headers,verify=sslv[verify_ssl]).json()[0]
+        text_1_embedding = requests.post(url = jailbreakraiurl,json={"inputs": [text_1]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT).json()[0]
+        text_2_embedding = requests.post(url = jailbreakraiurl,json={"inputs": [text_2]},headers=headers,verify=sslv[verify_ssl],timeout=HTTP_TIMEOUT).json()[0]
     
     dot_product = np.dot(text_1_embedding, text_2_embedding)
     norm_product = np.linalg.norm(text_1_embedding) * np.linalg.norm(text_2_embedding)

--- a/responsible-ai-moderationlayer/src/test_chunk_text.py
+++ b/responsible-ai-moderationlayer/src/test_chunk_text.py
@@ -1,0 +1,106 @@
+'''
+Copyright 2024-2025 Infosys Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
+import nltk
+from service.service import chunk_text, CHUNK_TOKEN_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _token_count(text: str) -> int:
+    """Return the NLTK token count for *text*."""
+    return len(nltk.word_tokenize(text))
+
+
+def _build_text(n_words: int) -> str:
+    """Return a synthetic string containing exactly *n_words* whitespace-separated words."""
+    return " ".join(f"word{i}" for i in range(n_words))
+
+
+# ---------------------------------------------------------------------------
+# Tests for chunk_text()
+# ---------------------------------------------------------------------------
+
+def test_short_text_returns_single_chunk():
+    """Text with fewer tokens than the limit is returned as a single-element list."""
+    text = _build_text(10)
+    result = chunk_text(text)
+    assert len(result) == 1
+    assert result[0] == text
+
+
+def test_text_at_exact_limit_returns_single_chunk():
+    """Text whose token count equals CHUNK_TOKEN_LIMIT is not split."""
+    text = _build_text(CHUNK_TOKEN_LIMIT)
+    result = chunk_text(text)
+    assert len(result) == 1
+
+
+def test_text_exceeding_limit_is_split():
+    """Text with more tokens than the limit must produce more than one chunk."""
+    text = _build_text(CHUNK_TOKEN_LIMIT + 50)
+    result = chunk_text(text)
+    assert len(result) > 1
+
+
+def test_each_chunk_respects_token_limit():
+    """Every chunk returned by chunk_text() must contain at most *limit* tokens."""
+    limit = 50
+    text = _build_text(300)
+    for chunk in chunk_text(text, limit=limit):
+        assert _token_count(chunk) <= limit, (
+            f"Chunk exceeds limit ({limit}): '{chunk[:60]}...'"
+        )
+
+
+def test_no_tokens_lost_after_chunking():
+    """The total token count across all chunks must equal the original token count."""
+    text = _build_text(CHUNK_TOKEN_LIMIT * 3 + 17)
+    original_count = _token_count(text)
+    chunks = chunk_text(text)
+    reassembled_count = sum(_token_count(c) for c in chunks)
+    assert reassembled_count == original_count
+
+
+def test_custom_limit_is_respected():
+    """Passing an explicit *limit* overrides CHUNK_TOKEN_LIMIT."""
+    limit = 10
+    text = _build_text(55)
+    chunks = chunk_text(text, limit=limit)
+    for chunk in chunks:
+        assert _token_count(chunk) <= limit
+
+
+def test_empty_string_returns_list_with_one_element():
+    """An empty string should not raise and should return a non-empty list."""
+    result = chunk_text("")
+    assert isinstance(result, list)
+    assert len(result) == 1
+
+
+def test_original_character_bug_is_fixed():
+    """Regression: the old code used len(token) (char count) for token_count
+    instead of 1 per token.  For single-character tokens that bug would allow
+    up to *limit* characters (not tokens) per chunk.  Verify that a text made
+    entirely of single-character tokens is split correctly by token count.
+    """
+    limit = 5
+    # Each word is a single letter — old code would allow up to 5 characters
+    # and would never split (each token counts as 1 char).
+    text = "a b c d e f g h i j"  # 10 single-char tokens
+    chunks = chunk_text(text, limit=limit)
+    # We expect the text to be split into at least 2 chunks.
+    assert len(chunks) >= 2, (
+        "Single-char-token text was not split — original char-count bug may still be present"
+    )
+    for chunk in chunks:
+        assert _token_count(chunk) <= limit


### PR DESCRIPTION
Addresses the performance issues in `service.py` raised in #55.

The chunking logic in `Toxicity.toxicity_check` and `Profanity.recognise` was identical — the same block duplicated in both places. Extracted it into a shared `chunk_text()` helper. In doing so, also fixed a bug in the original logic where `token_count += len(token)` was counting characters rather than tokens, meaning the 400-unit limit was being applied by character length rather than actual token count. The helper correctly uses `len(current)` to track tokens per chunk. Replaced the hardcoded `400` with a `CHUNK_TOKEN_LIMIT` constant since it appeared in multiple places.

Additionally, none of the `requests.post` or `requests.get` calls had a timeout configured, which means a slow or unresponsive upstream endpoint could stall the service indefinitely. Added `HTTP_TIMEOUT = 30` seconds to all 19 outbound calls. Also added the missing `verify=sslv[verify_ssl]` to the privacy endpoint call.

Eight unit tests for `chunk_text` in `test_chunk_text.py`, including a regression case for the character-count bug.

Closes #55