### PR TITLE
Fix IDOR vulnerability in /deleteFile: verify document ownership befo…

### DIFF
--- a/responsible-ai-admin/responsible-ai-admin/src/rai_admin/router/router.py
+++ b/responsible-ai-admin/responsible-ai-admin/src/rai_admin/router/router.py
@@ -1512,7 +1512,7 @@ async def pdfFile_anonymize(embId:str=Form(...))->list:
 
 
 @router.delete('/rai/admin/deleteFile')
-async def pdfFile_anonymize(docid:str=Form(...),userid:str=Form()):
+async def pdfFile_anonymize(docid:str=Form(...),userid:str=Form(...)):
     id = uuid.uuid4().hex
     request_id_var.set(id)
     log.info("Entered create usecase routing method")
@@ -1535,6 +1535,12 @@ async def pdfFile_anonymize(docid:str=Form(...),userid:str=Form()):
         # print("res----",response)
         return response
         
+    except PermissionError as pe:
+        log.error(str(pe))
+        log.info("exit create usecase routing method")
+        raise HTTPException(
+            status_code=403,
+            detail=str(pe))
     except RaiAdminException as cie:
         log.error(cie.__dict__)
         log.info("exit create usecase routing method")
@@ -1546,7 +1552,7 @@ async def pdfFile_anonymize(docid:str=Form(...),userid:str=Form()):
             status_code=500,
             detail="Please check with administration!!",
             headers={"X-Error": "Please check with administration!!"})
-    
+
 
 
 @modRouter.post('/rai/admin/createCustomeTemplate', response_model=CustomeTemplateStatus)

--- a/responsible-ai-admin/responsible-ai-admin/src/rai_admin/service/recognizer_service.py
+++ b/responsible-ai-admin/responsible-ai-admin/src/rai_admin/service/recognizer_service.py
@@ -1397,9 +1397,12 @@ class RAG:
             raise Exception(e)
         
     def delFiles(payload):
-        try:        
+        try:
             payload=AttributeDict(payload)
             # url=os.getenv("RAG_IP")+"/rag/v1/removeCache"
+            ownerCheck=docDetailDb.findall({"fileId":payload.docid,"userId":payload.userId})
+            if len(ownerCheck)==0:
+                raise PermissionError("User does not have permission to delete this document")
             isCache=docDetailDb.findall({"fileId":payload.docid,"isCache":"Y"})
             msg="Document Deleted Successfully"
             if(len(isCache)>0):
@@ -1418,6 +1421,8 @@ class RAG:
             # res=cacheDetailDb.delete(res.json())
             # print(res)
             return msg
+        except PermissionError:
+            raise
         except Exception as e:
             log.error(str(e))
             log.error("Line No:"+str(e.__traceback__.tb_lineno))


### PR DESCRIPTION
…re deletion

The delFiles function deleted documents purely by docid without checking that the document belongs to the requesting user. Added ownership verification by querying for both fileId and userId before allowing deletion, and made userid a required parameter in the route.

https://claude.ai/code/session_01RyPS2omYbR6iR5tF5K3inP